### PR TITLE
Change "xmlns" attribute in cxml dom transform

### DIFF
--- a/cxml/cxml-dom.lisp
+++ b/cxml/cxml-dom.lisp
@@ -50,7 +50,8 @@
                                                                    document-type))))))
                     (unless (and parent
                                  (equal (node-namespace node) (dom:namespace-uri parent)))
-                      (dom:set-attribute element "xmlns" (node-namespace node)))
+                      (dom:set-attribute-ns element (html5-constants:find-namespace "xmlns")
+                                            "xmlns" (node-namespace node)))
                     (element-map-attributes (lambda (name namespace value)
                                               (when (and (not xlink-defined)
                                                          (equal namespace (html5-constants:find-namespace "xlink")))


### PR DESCRIPTION
Hi,

I am using the html5-parser for parsing and then I want to work with cxml-stp.

The form I use for conversion is

``` lisp
(dom:map-document (cxml-stp:make-builder)
                  (html5-parser:parse-html5 *html* :dom :cxml))
```

This used to work 2 years ago, but now I get the following error.

```
attempt to represent a namespace declaration as an ATTRIBUTE
   [Condition of type CXML-STP:STP-ERROR]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] abort thread (#<THREAD "repl-thread" RUNNING {1002A39B93}>)

Backtrace:
  0: (CXML-STP:STP-ERROR "attempt to represent a namespace declaration as an ATTRIBUTE")
  1: ((:METHOD (SETF CXML-STP:LOCAL-NAME) (T CXML-STP:ATTRIBUTE)) "xmlns" #<error printing ATTRIBUTE {1002926473}>) [fast-method]
  2: (CXML-STP:MAKE-ATTRIBUTE "http://www.w3.org/1999/xhtml" "xmlns" NIL)
  3: ((:METHOD SAX:START-ELEMENT (CXML-STP-IMPL::BUILDER T T T T)) #<CXML-STP-IMPL::BUILDER {10028AE2F3}> "http://www.w3.org/1999/xhtml" #<unused argument> "html" (#S(SAX::STANDARD-ATTRIBUTE :NAMESPACE-URI..
  4: (SB-DEBUG::TRACE-CALL #<SB-DEBUG::TRACE-INFO SAX:START-ELEMENT> #<CLOSURE (LAMBDA (SB-PCL::.ARG0. SB-PCL::.ARG1. SB-PCL::.ARG2. SB-PCL::.ARG3. SB-PCL::.ARG4.) :IN "SYS:SRC;PCL;DLISP3.LISP") {10027B735..
  5: ((LAMBDA (CXML::CHILD) :IN DOM:MAP-DOCUMENT) #<RUNE-DOM::ELEMENT html {10029219D3}>)
  6: (DOM:MAP-NODE-LIST #<CLOSURE (LAMBDA (CXML::CHILD) :IN DOM:MAP-DOCUMENT) {1002922A7B}> #(#<RUNE-DOM::ELEMENT html {10029219D3}>))
  7: ((LABELS CXML::WALK :IN DOM:MAP-DOCUMENT) #<RUNE-DOM::DOCUMENT {1002921913}>)
  8: (DOM:MAP-DOCUMENT #<CXML-STP-IMPL::BUILDER {10028AE2F3}> #<RUNE-DOM::DOCUMENT {1002921913}> :INCLUDE-XMLNS-ATTRIBUTES NIL :INCLUDE-DOCTYPE NIL :INCLUDE-DEFAULT-VALUES NIL :RECODE #<unused argument>)
```

The attached patch fixes that.